### PR TITLE
タスク一覧を作成日時順に並び替える

### DIFF
--- a/app/views/layouts/task/_footer.html.haml
+++ b/app/views/layouts/task/_footer.html.haml
@@ -3,6 +3,10 @@
 
   = link_to t(:link_to_index), tasks_path
 
+  - if params[:action] == 'index'
+    ／
+    = link_to t(:link_to_new), new_task_path
+
   - if params[:action] == 'show'
     ／
     = link_to t(:link_to_edit), edit_task_path(task)

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,9 +1,7 @@
 = render 'layouts/task/header', page_title: @page_title
 
 %table#index
-  %tr
-    %td.add{ colspan: 8, align: 'right' }
-      = link_to t(:link_to_new), new_task_path
+
   %tr
     %th
       = Task.human_attribute_name :id

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -1,4 +1,5 @@
-require 'rails_helper'
+#require 'rails_helper'
+require 'features_helper'
 
 RSpec.feature 'リンクのテスト', type: :feature do
 
@@ -148,10 +149,11 @@ RSpec.feature 'タスク一覧のソートをテスト', type: :feature do
 
     header = find('header')
     expect(header).to have_content t('title_index', title: Task.model_name.human)
-    expect(page.find('table').all('tr')[2]).to have_content '平成のタスク'
-    expect(page.find('table').all('tr')[3]).to have_content '昭和のタスク'
-    expect(page.find('table').all('tr')[4]).to have_content '明治のタスク'
-
+    data = parse_data(included_th: false)
+    expect(data.map { |e| [e[0], e[1], e[2], e[3], e[4]] }).to eq [
+      ['3', '平成のタスク', '最新のタスク', 'doing', 'middle'],
+      ['2', '昭和のタスク', '中間のタスク', 'created', 'high'],
+      ['1', '明治のタスク', '最古のタスク', 'done', 'low']]
   end
 
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature 'タスク一覧のソートをテスト', type: :feature do
     header = find('header')
     expect(header).to have_content t('title_index', title: Task.model_name.human)
     data = parse_data
-    data.pop()
+
     expect(data.map { |e| [e[0], e[1], e[2], e[3], e[4]] }).to eq [
       ['3', '平成のタスク', '最新のタスク', 'doing', 'middle'],
       ['2', '昭和のタスク', '中間のタスク', 'created', 'high'],

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -148,12 +148,9 @@ RSpec.feature 'タスク一覧のソートをテスト', type: :feature do
 
     header = find('header')
     expect(header).to have_content t('title_index', title: Task.model_name.human)
-    tr = find(:xpath, '//*[@id="index"]/tbody/tr[3]')
-    expect(tr).to have_content '平成のタスク'
-    tr = find(:xpath, '//*[@id="index"]/tbody/tr[4]')
-    expect(tr).to have_content '昭和のタスク'
-    tr = find(:xpath, '//*[@id="index"]/tbody/tr[5]')
-    expect(tr).to have_content '明治のタスク'
+    expect(page.find('table').all('tr')[2]).to have_content '平成のタスク'
+    expect(page.find('table').all('tr')[3]).to have_content '昭和のタスク'
+    expect(page.find('table').all('tr')[4]).to have_content '明治のタスク'
 
   end
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -135,3 +135,27 @@ RSpec.feature 'タスクを削除するテスト', type: :feature, js: true do
   end
 
 end
+
+RSpec.feature 'タスク一覧のソートをテスト', type: :feature do
+  background do
+    Task.create!(id: 1, name: '明治のタスク', description: '最古のタスク', status: 'done', priority: 'low', created_at: '1900-01-01 00:51:00', updated_at: '2017-11-01 03:34:50')
+    Task.create!(id: 2, name: '昭和のタスク', description: '中間のタスク', status: 'created', priority: 'high', created_at: '1982-06-09 12:00:00', updated_at: '2016-12-01 09:21:45')
+    Task.create!(id: 3, name: '平成のタスク', description: '最新のタスク', status: 'doing', priority: 'middle', created_at: '2010-12-12 00:15:33', updated_at: '2018-02-01 23:43:20')
+  end
+
+  it '作成日時の降順で表示する' do
+    visit tasks_path()
+
+    header = find('header')
+    expect(header).to have_content t('title_index', title: Task.model_name.human)
+    tr = find(:xpath, '//*[@id="index"]/tbody/tr[3]')
+    expect(tr).to have_content '平成のタスク'
+    tr = find(:xpath, '//*[@id="index"]/tbody/tr[4]')
+    expect(tr).to have_content '昭和のタスク'
+    tr = find(:xpath, '//*[@id="index"]/tbody/tr[5]')
+    expect(tr).to have_content '明治のタスク'
+
+  end
+
+
+end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -149,7 +149,8 @@ RSpec.feature 'タスク一覧のソートをテスト', type: :feature do
 
     header = find('header')
     expect(header).to have_content t('title_index', title: Task.model_name.human)
-    data = parse_data(included_th: false)
+    data = parse_data
+    data.pop()
     expect(data.map { |e| [e[0], e[1], e[2], e[3], e[4]] }).to eq [
       ['3', '平成のタスク', '最新のタスク', 'doing', 'middle'],
       ['2', '昭和のタスク', '中間のタスク', 'created', 'high'],

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 def parse_data
-  row_count = page.find('table').all('tr').count
-  col_count = page.find('table').all("th").count
-  all_td = page.find('table').all("td").map { |e| e.text() }
-
-  table = []
-  row_count.times { table << all_td.shift(col_count) }
-  table
+  table = page.find('table').all('tr').map do |tr|
+    tr = tr.all('td').map { |td| td.text }
+  end
+  table.drop(1)
 end

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -1,15 +1,11 @@
 require 'rails_helper'
 
-def parse_data(included_th: true)
+def parse_data
   row_count = page.find('table').all('tr').count
   col_count = page.find('table').all("th").count
   all_td = page.find('table').all("td").map { |e| e.text() }
 
   table = []
-  row_count -= 1 unless included_th
-
-  for row in 0..(row_count - 1)
-    table << all_td.shift(col_count)
-  end
+  row_count.times { table << all_td.shift(col_count) }
   table
 end

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+def parse_data(return_row_count: false, included_th: true)
+  row_count = page.find('table').all('tr').count
+  col_count = page.find('table').all("th").count
+  all_td = page.find('table').all("td").map { |e| e.text() }
+
+  table = []
+  !included_th ? row_count = row_count - 1 : row_count
+
+  for row in 0..(row_count - 1)
+    table << all_td.shift(col_count)
+  end
+
+  return_row_count ? [ table, row_count ] : table
+end

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -1,16 +1,15 @@
 require 'rails_helper'
 
-def parse_data(return_row_count: false, included_th: true)
+def parse_data(included_th: true)
   row_count = page.find('table').all('tr').count
   col_count = page.find('table').all("th").count
   all_td = page.find('table').all("td").map { |e| e.text() }
 
   table = []
-  !included_th ? row_count = row_count - 1 : row_count
+  row_count -= 1 unless included_th
 
   for row in 0..(row_count - 1)
     table << all_td.shift(col_count)
   end
-
-  return_row_count ? [ table, row_count ] : table
+  table
 end


### PR DESCRIPTION
# ステップ11: タスク一覧を作成日時の順番で並び替えましょう
* 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
* 並び替えがうまく行っていることをfeature specで書いてみましょう